### PR TITLE
Add Remio to AI tools

### DIFF
--- a/data/tools.json
+++ b/data/tools.json
@@ -833,6 +833,26 @@
     "icon_url": "https://www.google.com/s2/favicons?domain=notebooklm.google.com&sz=64"
   },
   {
+    "id": "remio",
+    "name": "Remio",
+    "url": "https://remio.ai/",
+    "description": "本地优先的 AI 个人知识库，自动整理个人文件、网页、录音、邮件、聊天记录、图片和笔记",
+    "category": "办公",
+    "pricing": "Freemium",
+    "free_quota": "以官网为准",
+    "difficulty": 1,
+    "tags": [
+      "#notes",
+      "#knowledge-base",
+      "#local-first",
+      "#rag"
+    ],
+    "featured": false,
+    "use_cases": "个人知识管理、文件问答、会议资料整理、跨来源个人上下文检索",
+    "score": 75,
+    "icon_url": "https://www.google.com/s2/favicons?domain=remio.ai&sz=64"
+  },
+  {
     "id": "dify",
     "name": "Dify",
     "url": "https://dify.ai",

--- a/site/content/tools/remio.md
+++ b/site/content/tools/remio.md
@@ -1,0 +1,31 @@
++++
+title = "Remio"
+description = "本地优先的 AI 个人知识库，自动整理个人文件、网页、录音、邮件、聊天记录、图片和笔记"
+seo_title = "Remio 是什么？价格、优缺点、替代方案 - AI热榜"
+seo_description = "Remio：本地优先的 AI 个人知识库，自动整理个人文件、网页、录音、邮件、聊天记录、图片和笔记 这里整理了价格、免费额度、适合人群、优缺点和替代方案，帮助你快速判断它值不值得用。"
+seo_keywords = "Remio, 办公, AI工具, AI热榜, notes, knowledge-base, local-first, rag"
+slug = "remio"
+type = "tools"
+
+[params]
+id = "remio"
+name = "Remio"
+url = "https://remio.ai/"
+category = "办公"
+pricing = "Freemium"
+free_quota = "以官网为准"
+difficulty = 1
+trending = false
+featured = false
+use_cases = "个人知识管理、文件问答、会议资料整理、跨来源个人上下文检索"
+score = 75
+tags = ["#notes", "#knowledge-base", "#local-first", "#rag"]
+pros = ["本地优先", "支持多格式资料解析", "可以建立本地索引和向量", "适合检索个人上下文"]
+cons = ["需要安装桌面客户端", "价格和免费额度以官网为准"]
+best_for = ["知识工作者", "研究人员", "需要整理大量个人资料的用户", "希望减少手动找文件和重复上传资料的人"]
+alternatives = ["notebooklm", "notion-ai"]
++++
+
+<!-- AUTO-GENERATED: tool page -->
+
+Remio 是一款偏 办公 场景的 AI 工具。它更适合作为本地优先的个人知识库和上下文检索工具，用来整理文件、网页、录音、邮件、聊天记录、图片和笔记，并通过本地索引与向量检索减少手动翻找资料或把整篇文档交给 AI 的成本。

--- a/site/data/tools.json
+++ b/site/data/tools.json
@@ -833,6 +833,26 @@
     "icon_url": "https://www.google.com/s2/favicons?domain=notebooklm.google.com&sz=64"
   },
   {
+    "id": "remio",
+    "name": "Remio",
+    "url": "https://remio.ai/",
+    "description": "本地优先的 AI 个人知识库，自动整理个人文件、网页、录音、邮件、聊天记录、图片和笔记",
+    "category": "办公",
+    "pricing": "Freemium",
+    "free_quota": "以官网为准",
+    "difficulty": 1,
+    "tags": [
+      "#notes",
+      "#knowledge-base",
+      "#local-first",
+      "#rag"
+    ],
+    "featured": false,
+    "use_cases": "个人知识管理、文件问答、会议资料整理、跨来源个人上下文检索",
+    "score": 75,
+    "icon_url": "https://www.google.com/s2/favicons?domain=remio.ai&sz=64"
+  },
+  {
     "id": "dify",
     "name": "Dify",
     "url": "https://dify.ai",


### PR DESCRIPTION
## Summary

Adds Remio as an AI office/productivity tool:

- adds Remio to data/tools.json
- adds Remio to site/data/tools.json
- adds a generated-style tool detail page at site/content/tools/remio.md

Remio fits the existing NotebookLM / Notion AI style knowledge-management entries as a local-first AI personal knowledge base desktop app. It parses files, webpages, recordings, emails, chat history, images, and notes into local indexes and vectors, helping users retrieve personal context faster while reducing repeated manual file searching and whole-document prompt token cost.

Official site: https://remio.ai/